### PR TITLE
Make test file executable.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,7 @@ before_install:
 install:
 - sudo apt-get install -q -y --force-yes commandbox
 - box install
+before_script:
+- chmod +x test
 script:
 - "./test"


### PR DESCRIPTION
Thanks for sharing your code Dominic. I've used it to get CI running on Xindi (https://github.com/simonbingham/xindi/pull/143). One issue I spotted and fixed was an error if the `test` file is not executable. This change fixes it, but see what you think.
