### PR TITLE
Update travis.yml to not require sudo, runs faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: java
-sudo: required
+sudo: false
 before_install:
-- echo "deb http://downloads.ortussolutions.com/debs/noarch /" > commandbox.list
-- sudo mv commandbox.list /etc/apt/sources.list.d/commandbox.list
-- sudo apt-get update
+- mkdir /tmp/bin
+- export PATH=$PATH:/tmp/bin
 install:
-- sudo apt-get install -q -y --force-yes commandbox
-- box install
+- curl --location 'https://www.ortussolutions.com/parent/download/commandbox/type/bin' -o /tmp/box.zip
+- unzip /tmp/box.zip -d /tmp/bin
+- /tmp/bin/box install
 script:
 - "./test"


### PR DESCRIPTION
Runs about 20 seconds faster on travis-ci because it allows your test to run on their new docker infrastructure instead of the legacy infrastructure. You can see an example of my output from travis here using sudo:false https://travis-ci.org/foundeo/cfdocs/builds/79878933
